### PR TITLE
Log rotation practice added

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,6 +31,8 @@ For more detailed information see [Best practices for writing Dockerfiles](https
 ### Tagging
 Use tags to reference specific versions of your image.
 
+Tags could be used to denote a specific Docker container image. Hence, the tagging strategy must include leveraging a unique counter like `build id` from a CI Server (eg: Jenkins) to help with identifying the right Image. 
+
 For more detailed information see [The tag command](https://docs.docker.com/engine/reference/commandline/tag/).
 
 

--- a/README.md
+++ b/README.md
@@ -33,6 +33,14 @@ Use tags to reference specific versions of your image.
 
 For more detailed information see [The tag command](https://docs.docker.com/engine/reference/commandline/tag/).
 
+
+### Log Rotation
+
+Use `--log-opt` to allow log rotation if the containers you are creating are too verbose and are created too often thanks to a continuous deployment process. 
+
+For more detailed information see [The log driver options](https://docs.docker.com/engine/admin/logging/overview/#/json-file-options).
+
+
 ## Docker container
 ### One Container - One Responsibility - One process
 If a container only has one responsibility, which should in almost all cases one process, it makes it much eaiser to scale horizontally or reuse the container in general.

--- a/README.md
+++ b/README.md
@@ -38,7 +38,7 @@ For more detailed information see [The tag command](https://docs.docker.com/engi
 
 Use `--log-opt` to allow log rotation if the containers you are creating are too verbose and are created too often thanks to a continuous deployment process. 
 
-For more detailed information see [The log driver options](https://docs.docker.com/engine/admin/logging/overview/#/json-file-options).
+For more detailed information see [the log driver options](https://docs.docker.com/engine/admin/logging/overview/#/json-file-options).
 
 
 ## Docker container


### PR DESCRIPTION
Log rotation is usually missed as by default logs are not rolled over for Docker containers. This adds up to the disk space quite quickly if too many containers are created, and they being too verbose. 
